### PR TITLE
Notifying Incoming call 2 times.

### DIFF
--- a/CallKitSample.iOS/AppDelegate.cs
+++ b/CallKitSample.iOS/AppDelegate.cs
@@ -51,32 +51,7 @@ namespace CallKitSample.iOS
                 TwilioService.Setnotification(payload);
             }
         }
-
-        [Export("pushRegistry:didReceiveIncomingPushWithPayload:forType:withCompletionHandler:")]
-        public void DidReceiveIncomingPush(PKPushRegistry registry, PKPushPayload payload, string type,Action completion)
-        {
-            try
-            {
-                LoggerService.Log("Info", "My push is coming(Inside Action method!");
-             
-                var callerid = payload.DictionaryPayload["twi_from"].ToString();
-                LoggerService.Log("Info",$"from: {callerid}");
-
-                if (payload != null)
-                {
-                    TwilioService.Setnotification(payload);
-                    TwilioVoiceHelper.activeCallUuid = new NSUuid();
-                    LoggerService.Log("Info", "CallUUID:" + TwilioVoiceHelper.activeCallUuid);
-                    CallProviderDelegate.ReportIncomingCall(TwilioVoiceHelper.activeCallUuid, callerid);
-                }
-                completion(); 
-            }
-            catch (Exception ex)
-            {
-                LogHelper.Info($"Inside DidReceiveIncomingPush:: Error:: {ex.Message} {ex.StackTrace}");
-            }
-        }
-
+        
         public override bool OpenUrl(UIApplication application, NSUrl url, string sourceApplication, NSObject annotation)
         {
             // Get handle from url

--- a/CallKitSample.iOS/AppDelegate.cs
+++ b/CallKitSample.iOS/AppDelegate.cs
@@ -46,9 +46,27 @@ namespace CallKitSample.iOS
         public void DidReceiveIncomingPush(PKPushRegistry registry, PKPushPayload payload, string type)
         {
             Console.WriteLine("My push is coming!");
-            if (payload != null)
+            
+        }
+        [Export("pushRegistry:didReceiveIncomingPushWithPayload:forType:withCompletionHandler:")]
+        public void DidReceiveIncomingPush(PKPushRegistry registry, PKPushPayload payload, string type, Action completion)
+        {
+            try
             {
-                TwilioService.Setnotification(payload);
+                LoggerService.Log("Info", "My push is coming(Inside Action method!");
+
+                var callerid = payload.DictionaryPayload["twi_from"].ToString();
+                LoggerService.Log("Info", $"from: {callerid}");
+
+                if (payload != null)
+                {
+                    TwilioService.Setnotification(payload);
+                }
+                completion();
+            }
+            catch (Exception ex)
+            {
+                LogHelper.Info($"Inside DidReceiveIncomingPush:: Error:: {ex.Message} {ex.StackTrace}");
             }
         }
         


### PR DESCRIPTION
Removed AppDelegate.DidReceiveIncomingPush()

Already Notifying Incoming Call in TwilioVoiceHelper.NotificationDelegateOnCallInviteReceivedEvent so no need to again notify in  AppDelegate.DidReceiveIncomingPush().
